### PR TITLE
Android security 11.0.0 release 53

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -4,7 +4,7 @@
   <remote  name="aosp"
            fetch=".."
            review="https://android-review.googlesource.com/" />
-  <default revision="refs/tags/android-security-11.0.0_r1"
+  <default revision="refs/tags/android-security-11.0.0_r49"
            remote="aosp"
            sync-j="4" />
 

--- a/default.xml
+++ b/default.xml
@@ -4,9 +4,12 @@
   <remote  name="aosp"
            fetch=".."
            review="https://android-review.googlesource.com/" />
-  <default revision="refs/tags/android-security-11.0.0_r51"
+  <default revision="refs/tags/android-security-11.0.0_r52"
            remote="aosp"
            sync-j="4" />
+
+  <superproject name="platform/superproject" remote="aosp" revision="android-security-11.0.0_r52" />
+  <contactinfo bugurl="go/repo-bug" />
 
   <project path="build/make" name="platform/build" groups="pdk" >
     <copyfile src="core/root.mk" dest="Makefile" />

--- a/default.xml
+++ b/default.xml
@@ -4,11 +4,11 @@
   <remote  name="aosp"
            fetch=".."
            review="https://android-review.googlesource.com/" />
-  <default revision="refs/tags/android-security-11.0.0_r52"
+  <default revision="refs/tags/android-security-11.0.0_r53"
            remote="aosp"
            sync-j="4" />
 
-  <superproject name="platform/superproject" remote="aosp" revision="android-security-11.0.0_r52" />
+  <superproject name="platform/superproject" remote="aosp" revision="android-security-11.0.0_r53" />
   <contactinfo bugurl="go/repo-bug" />
 
   <project path="build/make" name="platform/build" groups="pdk" >

--- a/default.xml
+++ b/default.xml
@@ -4,7 +4,7 @@
   <remote  name="aosp"
            fetch=".."
            review="https://android-review.googlesource.com/" />
-  <default revision="refs/tags/android-security-11.0.0_r49"
+  <default revision="refs/tags/android-security-11.0.0_r50"
            remote="aosp"
            sync-j="4" />
 

--- a/default.xml
+++ b/default.xml
@@ -4,7 +4,7 @@
   <remote  name="aosp"
            fetch=".."
            review="https://android-review.googlesource.com/" />
-  <default revision="refs/tags/android-security-11.0.0_r50"
+  <default revision="refs/tags/android-security-11.0.0_r51"
            remote="aosp"
            sync-j="4" />
 

--- a/default.xml
+++ b/default.xml
@@ -4,7 +4,7 @@
   <remote  name="aosp"
            fetch=".."
            review="https://android-review.googlesource.com/" />
-  <default revision="android11-release"
+  <default revision="android11-security-release"
            remote="aosp"
            sync-j="4" />
 
@@ -628,7 +628,7 @@
   <project path="packages/apps/TvSettings" name="platform/packages/apps/TvSettings" groups="pdk-fs" />
   <project path="packages/apps/TV" name="platform/packages/apps/TV" groups="pdk" />
   <project path="packages/apps/UniversalMediaPlayer" name="platform/packages/apps/UniversalMediaPlayer" />
-  <project path="packages/apps/WallpaperPicker" name="platform/packages/apps/WallpaperPicker" groups="pdk-fs"  />
+  <project path="packages/apps/WallpaperPicker" name="platform/packages/apps/WallpaperPicker" groups="pdk-fs" />
   <project path="packages/apps/WallpaperPicker2" name="platform/packages/apps/WallpaperPicker2" groups="pdk-fs" />
   <project path="packages/inputmethods/LatinIME" name="platform/packages/inputmethods/LatinIME" groups="pdk-fs" />
   <project path="packages/inputmethods/LeanbackIME" name="platform/packages/inputmethods/LeanbackIME" groups="pdk-fs" />

--- a/default.xml
+++ b/default.xml
@@ -4,7 +4,7 @@
   <remote  name="aosp"
            fetch=".."
            review="https://android-review.googlesource.com/" />
-  <default revision="android11-security-release"
+  <default revision="refs/tags/android-security-11.0.0_r1"
            remote="aosp"
            sync-j="4" />
 


### PR DESCRIPTION
Merge tag 'android-security-11.0.0_r53' of https://android.googlesource.com/platform/manifest into arrow-11.0

Android security 11.0.0 release 53

Manifest for Android security-11.0.0 Release 53

Change-Id: d6123321038984cc5bdb4aba66fbc6ba1d07c820