### PR TITLE
Feature/11.0.0 r53

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+HELP.md
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**
+!**/src/test/**
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+
+### VS Code ###
+.vscode/

--- a/arrow.xml
+++ b/arrow.xml
@@ -2,7 +2,7 @@
 <manifest>
 
   <project path="manifest" name="android_manifest" remote="arrow" />
-  <project path="build/make" name="android_build" remote="arrow" >
+  <project path="build/make" name="android_build" remote="arrow-st-schilling" >
     <copyfile src="core/root.mk" dest="Makefile" />
     <linkfile src="CleanSpec.mk" dest="build/CleanSpec.mk" />
     <linkfile src="buildspec.mk.default" dest="build/buildspec.mk.default" />
@@ -31,46 +31,46 @@
   <project path="device/qcom/sepolicy_vndr" name="android_device_qcom_sepolicy_vndr" remote="arrow" />
 
   <!-- framework repos -->
-  <project path="frameworks/av" name="android_frameworks_av" remote="arrow" />
-  <project path="frameworks/base" name="android_frameworks_base" remote="arrow" />
+  <project path="frameworks/av" name="android_frameworks_av" remote="arrow-st-schilling" />
+  <project path="frameworks/base" name="android_frameworks_base" remote="arrow-st-schilling" />
   <project path="frameworks/libs/systemui" name="android_frameworks_libs_systemui" remote="arrow" />
-  <project path="frameworks/native" name="android_frameworks_native" remote="arrow" />
+  <project path="frameworks/native" name="android_frameworks_native" remote="arrow-st-schilling" />
   <project path="frameworks/opt/telephony" name="android_frameworks_opt_telephony" remote="arrow" />
   <project path="frameworks/opt/net/ims" name="android_frameworks_opt_net_ims" remote="arrow" />
   <project path="frameworks/opt/net/wifi" name="android_frameworks_opt_net_wifi" remote="arrow" />
 
   <!-- packages repos -->
   <project path="packages/apps/ArrowPrebuilts" name="android_packages_apps_ArrowPrebuilts" remote="arrow" clone-depth="1" />
-  <project path="packages/apps/Bluetooth" name="android_packages_apps_Bluetooth" remote="arrow" />
-  <project path="packages/apps/Contacts" name="android_packages_apps_Contacts" remote="arrow" />
+  <project path="packages/apps/Bluetooth" name="android_packages_apps_Bluetooth" remote="arrow-st-schilling" />
+  <project path="packages/apps/Contacts" name="android_packages_apps_Contacts" remote="arrow-st-schilling" />
   <project path="packages/apps/Camera2" name="android_packages_apps_Camera2" remote="arrow" />
   <project path="packages/apps/DeskClock" name="android_packages_apps_DeskClock" remote="arrow" />
-  <project path="packages/apps/Dialer" name="android_packages_apps_Dialer" remote="arrow" />
+  <project path="packages/apps/Dialer" name="android_packages_apps_Dialer" remote="arrow-st-schilling" />
   <project path="packages/apps/FMRadio" name="android_packages_apps_FMRadio" remote="arrow" />
-  <project path="packages/apps/Launcher3" name="android_packages_apps_Launcher3" remote="arrow" />
+  <project path="packages/apps/Launcher3" name="android_packages_apps_Launcher3" remote="arrow-st-schilling" />
   <project path="packages/apps/Messaging" name="android_packages_apps_Messaging" remote="arrow" />
-  <project path="packages/apps/Nfc" name="android_packages_apps_Nfc" remote="arrow" />
-  <project path="packages/apps/Settings" name="android_packages_apps_Settings" remote="arrow" />
+  <project path="packages/apps/Nfc" name="android_packages_apps_Nfc" remote="arrow-st-schilling" />
+  <project path="packages/apps/Settings" name="android_packages_apps_Settings" remote="arrow-st-schilling" />
   <project path="packages/apps/SettingsIntelligence" name="android_packages_apps_SettingsIntelligence" remote="arrow" />
   <project path="packages/apps/Snap" name="android_packages_apps_Snap" remote="arrow" />
   <project path="packages/apps/ThemePicker" name="android_packages_apps_ThemePicker" remote="arrow" />
   <project path="packages/apps/WallpaperPicker2" name="android_packages_apps_WallpaperPicker2" remote="arrow" />
   <project path="packages/inputmethods/LatinIME" name="android_packages_inputmethods_LatinIME" remote="arrow" />
-  <project path="packages/providers/ContactsProvider" name="android_packages_providers_ContactsProvider" remote="arrow" />
-  <project path="packages/providers/DownloadProvider" name="android_packages_providers_DownloadProvider" remote="arrow" />
+  <project path="packages/providers/ContactsProvider" name="android_packages_providers_ContactsProvider" remote="arrow-st-schilling" />
+  <project path="packages/providers/DownloadProvider" name="android_packages_providers_DownloadProvider" remote="arrow-st-schilling" />
   <project path="packages/resources/devicesettings" name="android_packages_resources_devicesettings" remote="arrow" />
-  <project path="packages/services/Telephony" name="android_packages_services_Telephony" remote="arrow" />
-  <project path="packages/services/Telecomm" name="android_packages_services_Telecomm" remote="arrow" />
+  <project path="packages/services/Telephony" name="android_packages_services_Telephony" remote="arrow-st-schilling" />
+  <project path="packages/services/Telecomm" name="android_packages_services_Telecomm" remote="arrow-st-schilling" />
   <project path="packages/services/OmniJaws" name="android_packages_services_OmniJaws" remote="arrow" />
   <project path="packages/apps/Updater" name="android_packages_apps_Updater" remote="arrow" />
-  <project path="packages/modules/NetworkStack" name="android_packages_modules_NetworkStack" remote="arrow" />
+  <project path="packages/modules/NetworkStack" name="android_packages_modules_NetworkStack" remote="arrow-st-schilling" />
   <project path="packages/apps/PermissionController" name="android_packages_apps_PackageInstaller" remote="arrow" />
   <project path="packages/apps/SimpleDeviceConfig" name="android_packages_apps_SimpleDeviceConfig" remote="arrow" />
   <project path="packages/apps/FaceUnlockService" name="android_packages_apps_FaceUnlockService" remote="arrow-gitlab" />
   <project path="packages/apps/CarrierConfig" name="android_packages_apps_CarrierConfig" remote="arrow" />
-  <project path="packages/apps/ManagedProvisioning" name="android_packages_apps_ManagedProvisioning" remote="arrow" />
-  <project path="packages/providers/MediaProvider" name="android_packages_providers_MediaProvider" remote="arrow" />
-  <project path="packages/apps/KeyChain" name="android_packages_apps_KeyChain" remote="arrow" />
+  <project path="packages/apps/ManagedProvisioning" name="android_packages_apps_ManagedProvisioning" remote="arrow-st-schilling" />
+  <project path="packages/providers/MediaProvider" name="android_packages_providers_MediaProvider" remote="arrow-st-schilling" />
+  <project path="packages/apps/KeyChain" name="android_packages_apps_KeyChain" remote="arrow-st-schilling" />
 
   <!-- hardware repos -->
   <project path="hardware/qcom-caf/bootctrl" name="android_hardware_qcom_bootctrl" groups="qcom,pdk-qcom" remote="arrow" revision="arrow-11.0-caf" />
@@ -159,11 +159,11 @@
   <project path="hardware/qcom/power" name="android_hardware_qcom_power" groups="qcom,pdk" remote="arrow" />
   <project path="hardware/ril" name="android_hardware_ril" groups="pdk" remote="arrow" />
   <project path="hardware/qcom/bt" name="android_hardware_qcom_bt" groups="qcom" remote="arrow" />
-  <project path="hardware/interfaces" name="android_hardware_interfaces" remote="arrow" />
+  <project path="hardware/interfaces" name="android_hardware_interfaces" remote="arrow-st-schilling" />
   <project path="hardware/arrow/interfaces" name="android_hardware_arrow_interfaces" remote="arrow" />
   <project path="hardware/libhardware" name="android_hardware_libhardware" remote="arrow" />
   <project path="hardware/libhardware_legacy" name="android_hardware_libhardware_legacy" remote="arrow" />
-  <project path="hardware/nxp/nfc" name="android_hardware_nxp_nfc" remote="arrow" />
+  <project path="hardware/nxp/nfc" name="android_hardware_nxp_nfc" remote="arrow-st-schilling" />
 
   <!-- external repos -->
   <project path="external/ant-wireless/ant_client" name="android_external_ant-wireless_ant_client" remote="arrow" />
@@ -173,10 +173,10 @@
   <project path="external/ant-wireless/hidl" name="android_external_ant-wireless_hidl" remote="arrow" />
   <project path="external/chromium-webview" name="android_external_chromium-webview" remote="arrow" revision="master" clone-depth="1" />
   <project path="external/connectivity" name="android_external_connectivity" remote="arrow" />
-  <project path="external/gptfdisk" name="android_external_gptfdisk" remote="arrow" />
+  <project path="external/gptfdisk" name="android_external_gptfdisk" remote="arrow-st-schilling" />
   <project path="external/guice" name="android_external_guice" remote="arrow" />
-  <project path="external/libavc" name="android_external_libavc" remote="arrow" />
-  <project path="external/libexif" name="android_external_libexif" remote="arrow" />
+  <project path="external/libavc" name="android_external_libavc" remote="arrow-st-schilling" />
+  <project path="external/libexif" name="android_external_libexif" remote="arrow-st-schilling" />
   <project path="external/selinux" name="android_external_selinux" remote="arrow" />
   <project path="external/tinycompress" name="android_external_tinycompress" remote="arrow" />
   <project path="external/json-c" name="android_external_json-c" remote="arrow" />
@@ -188,9 +188,9 @@
   <project path="external/e2fsprogs" name="android_external_e2fsprogs" remote="arrow" />
   <project path="external/libnfc-nxp" name="android_external_libnfc-nxp" remote="arrow" />
   <project path="external/faceunlock" name="android_external_faceunlock" remote="arrow-gitlab" />
-  <project path="external/wpa_supplicant_8" name="android_external_wpa_supplicant_8" remote="arrow" />
-  <project path="external/robolectric-shadows" name="android_external_robolectric-shadows" remote="arrow" />
-  <project path="external/tremolo" name="android_external_tremolo" remote="arrow" />
+  <project path="external/wpa_supplicant_8" name="android_external_wpa_supplicant_8" remote="arrow-st-schilling" />
+  <project path="external/robolectric-shadows" name="android_external_robolectric-shadows" remote="arrow-st-schilling" />
+  <project path="external/tremolo" name="android_external_tremolo" remote="arrow-st-schilling" />
 
   <!-- prebuilt repos -->
   <project path="prebuilts/tools-extras" name="android_prebuilts_tools-extras" remote="arrow" />
@@ -202,19 +202,19 @@
   <project path="system/qcom" name="android_system_qcom" remote="arrow" />
   <project path="system/core" name="android_system_core" remote="arrow" />
   <project path="system/libufdt" name="android_system_libufdt" remote="arrow" />
-  <project path="system/bt" name="android_system_bt" remote="arrow" />
+  <project path="system/bt" name="android_system_bt" remote="arrow-st-schilling" />
   <project path="system/tools/dtbtool" name="android_system_tools_dtbtool" remote="arrow" />
-  <project path="system/tools/hidl" name="android_system_tools_hidl" remote="arrow" />
+  <project path="system/tools/hidl" name="android_system_tools_hidl" remote="arrow-st-schilling" />
   <project path="system/tools/mkbootimg" name="android_system_tools_mkbootimg" remote="arrow" />
   <project path="system/extras" name="android_system_extras" remote="arrow" />
   <project path="system/incremental_delivery" name="android_system_incremental_delivery" remote="arrow" />
-  <project path="system/netd" name="android_system_netd" remote="arrow" />
+  <project path="system/netd" name="android_system_netd" remote="arrow-st-schilling" />
   <project path="system/vold" name="android_system_vold" groups="pdk" remote="arrow" />
   <project path="system/update_engine" name="android_system_update_engine" groups="pdk" remote="arrow" />
-  <project path="system/sepolicy" name="android_system_sepolicy" remote="arrow" />
+  <project path="system/sepolicy" name="android_system_sepolicy" remote="arrow-st-schilling" />
   <project path="system/media" name="android_system_media" remote="arrow" />
-  <project path="system/nfc" name="android_system_nfc" remote="arrow" />
-  <project path="system/tools/aidl" name="android_system_tools_aidl" remote="arrow" />
+  <project path="system/nfc" name="android_system_nfc" remote="arrow-st-schilling" />
+  <project path="system/tools/aidl" name="android_system_tools_aidl" remote="arrow-st-schilling" />
 
   <!-- tools repos -->
   <project path="tools/extract-utils" name="android_tools_extract-utils" remote="arrow" />

--- a/default.xml
+++ b/default.xml
@@ -4,7 +4,7 @@
   <remote  name="aosp"
            fetch=".."
            review="https://android-review.googlesource.com/" />
-  <default revision="refs/tags/android-security-11.0.0_r1"
+  <default revision="refs/tags/android-security-11.0.0_r49"
            remote="aosp"
            sync-j="4" />
 

--- a/default.xml
+++ b/default.xml
@@ -4,9 +4,12 @@
   <remote  name="aosp"
            fetch=".."
            review="https://android-review.googlesource.com/" />
-  <default revision="refs/tags/android-security-11.0.0_r51"
+  <default revision="refs/tags/android-security-11.0.0_r52"
            remote="aosp"
            sync-j="4" />
+
+  <superproject name="platform/superproject" remote="aosp" revision="android-security-11.0.0_r52" />
+  <contactinfo bugurl="go/repo-bug" />
 
   <project path="build/make" name="platform/build" groups="pdk" >
     <copyfile src="core/root.mk" dest="Makefile" />

--- a/default.xml
+++ b/default.xml
@@ -4,11 +4,11 @@
   <remote  name="aosp"
            fetch=".."
            review="https://android-review.googlesource.com/" />
-  <default revision="refs/tags/android-security-11.0.0_r52"
+  <default revision="refs/tags/android-security-11.0.0_r53"
            remote="aosp"
            sync-j="4" />
 
-  <superproject name="platform/superproject" remote="aosp" revision="android-security-11.0.0_r52" />
+  <superproject name="platform/superproject" remote="aosp" revision="android-security-11.0.0_r53" />
   <contactinfo bugurl="go/repo-bug" />
 
   <project path="build/make" name="platform/build" groups="pdk" >

--- a/default.xml
+++ b/default.xml
@@ -4,7 +4,7 @@
   <remote  name="aosp"
            fetch=".."
            review="https://android-review.googlesource.com/" />
-  <default revision="refs/tags/android-security-11.0.0_r49"
+  <default revision="refs/tags/android-security-11.0.0_r50"
            remote="aosp"
            sync-j="4" />
 

--- a/default.xml
+++ b/default.xml
@@ -4,7 +4,7 @@
   <remote  name="aosp"
            fetch=".."
            review="https://android-review.googlesource.com/" />
-  <default revision="refs/tags/android-security-11.0.0_r50"
+  <default revision="refs/tags/android-security-11.0.0_r51"
            remote="aosp"
            sync-j="4" />
 

--- a/default.xml
+++ b/default.xml
@@ -11,8 +11,13 @@
   <remote  name="gitlab"
            fetch="https://gitlab.com/" />
 
-  <remote  name="arrow"
+  <remote  name="arrow-st-schilling"
            fetch="https://github.com/st-schilling"
+           review="https://review.arrowos.net/"
+           revision="feature/11.0.0_r53" />
+
+  <remote  name="arrow"
+           fetch="https://github.com/ArrowOS"
            review="https://review.arrowos.net/"
            revision="refs/heads/arrow-11.0" />
 
@@ -31,7 +36,17 @@
            review="https://review.arrowos.net/"
            revision="refs/heads/arrow-11.0" />
 
-  <default revision="refs/tags/android-security-11.0.0_r53"
+  <remote  name="aosp-r48"
+           fetch="https://android.googlesource.com/"
+           review="https://android-review.googlesource.com/"
+           revision="refs/tags/android-11.0.0_r48" />
+
+  <!--  <default revision="refs/tags/android-security-11.0.0_r53"-->
+  <!--           remote="aosp"-->
+  <!--           sync-j="4"-->
+  <!--           sync-c="true"/>-->
+
+  <default revision="refs/tags/android-11.0.0_r48"
            remote="aosp"
            sync-j="4"
            sync-c="true"/>
@@ -561,16 +576,16 @@
   <project path="hardware/qcom/sdm845/media" name="platform/hardware/qcom/sdm845/media" groups="generic_fs,qcom_sdm845" />
   <project path="hardware/qcom/sdm845/thermal" name="platform/hardware/qcom/sdm845/thermal" groups="generic_fs,qcom_sdm845" />
   <project path="hardware/qcom/sdm845/vr" name="platform/hardware/qcom/sdm845/vr" groups="generic_fs,qcom_sdm845" />
-  <project path="hardware/qcom/sm7150/gps" name="platform/hardware/qcom/sm7150/gps" groups="qcom_sm7150" >
+  <project path="hardware/qcom/sm7150/gps" name="platform/hardware/qcom/sm7150/gps" groups="qcom_sm7150"  remote="aosp-r48" >
     <linkfile src="os_pickup.mk" dest="hardware/qcom/sm7150/Android.mk" />
     <linkfile src="os_pickup.bp" dest="hardware/qcom/sm7150/Android.bp" />
   </project>
-  <project path="hardware/qcom/sm7250/display" name="platform/hardware/qcom/sm7250/display" groups="qcom_sm7250" />
-  <project path="hardware/qcom/sm7250/gps" name="platform/hardware/qcom/sm7250/gps" groups="qcom_sm7250" >
+  <project path="hardware/qcom/sm7250/display" name="platform/hardware/qcom/sm7250/display" groups="qcom_sm7250"  remote="aosp-r48"/>
+  <project path="hardware/qcom/sm7250/gps" name="platform/hardware/qcom/sm7250/gps" groups="qcom_sm7250"  remote="aosp-r48">
     <linkfile src="os_pickup.mk" dest="hardware/qcom/sm7250/Android.mk" />
     <linkfile src="os_pickup.bp" dest="hardware/qcom/sm7250/Android.bp" />
   </project>
-  <project path="hardware/qcom/sm7250/media" name="platform/hardware/qcom/sm7250/media" groups="qcom_sm7250" />
+  <project path="hardware/qcom/sm7250/media" name="platform/hardware/qcom/sm7250/media" groups="qcom_sm7250"  remote="aosp-r48"/>
   <project path="hardware/qcom/sm8150/data/ipacfg-mgr" name="platform/hardware/qcom/sm8150/data/ipacfg-mgr" groups="qcom_sm8150" >
     <linkfile src="os_pickup.mk" dest="hardware/qcom/sm8150/Android.mk" />
     <linkfile src="os_pickup.bp" dest="hardware/qcom/sm8150/Android.bp" />

--- a/default.xml
+++ b/default.xml
@@ -14,7 +14,7 @@
   <remote  name="arrow-st-schilling"
            fetch="https://github.com/st-schilling"
            review="https://review.arrowos.net/"
-           revision="feature/11.0.0_r53" />
+           revision="refs/tags/11.0.0_r53" />
 
   <remote  name="arrow"
            fetch="https://github.com/ArrowOS"
@@ -46,7 +46,7 @@
            sync-j="4"
            sync-c="true"/>
 
-  <superproject name="platform/superproject" remote="aosp" revision="android-security-11.0.0_r53" />
+  <superproject name="platform/superproject" remote="aosp" />
   <contactinfo bugurl="go/repo-bug" />
 
   <project path="build/make" name="platform/build" groups="pdk" >

--- a/default.xml
+++ b/default.xml
@@ -41,11 +41,6 @@
            review="https://android-review.googlesource.com/"
            revision="refs/tags/android-11.0.0_r48" />
 
-  <!--  <default revision="refs/tags/android-security-11.0.0_r53"-->
-  <!--           remote="aosp"-->
-  <!--           sync-j="4"-->
-  <!--           sync-c="true"/>-->
-
   <default revision="refs/tags/android-11.0.0_r48"
            remote="aosp"
            sync-j="4"

--- a/default.xml
+++ b/default.xml
@@ -4,7 +4,7 @@
   <remote  name="aosp"
            fetch=".."
            review="https://android-review.googlesource.com/" />
-  <default revision="android11-release"
+  <default revision="android11-security-release"
            remote="aosp"
            sync-j="4" />
 
@@ -628,7 +628,7 @@
   <project path="packages/apps/TvSettings" name="platform/packages/apps/TvSettings" groups="pdk-fs" />
   <project path="packages/apps/TV" name="platform/packages/apps/TV" groups="pdk" />
   <project path="packages/apps/UniversalMediaPlayer" name="platform/packages/apps/UniversalMediaPlayer" />
-  <project path="packages/apps/WallpaperPicker" name="platform/packages/apps/WallpaperPicker" groups="pdk-fs"  />
+  <project path="packages/apps/WallpaperPicker" name="platform/packages/apps/WallpaperPicker" groups="pdk-fs" />
   <project path="packages/apps/WallpaperPicker2" name="platform/packages/apps/WallpaperPicker2" groups="pdk-fs" />
   <project path="packages/inputmethods/LatinIME" name="platform/packages/inputmethods/LatinIME" groups="pdk-fs" />
   <project path="packages/inputmethods/LeanbackIME" name="platform/packages/inputmethods/LeanbackIME" groups="pdk-fs" />

--- a/default.xml
+++ b/default.xml
@@ -4,7 +4,7 @@
   <remote  name="aosp"
            fetch=".."
            review="https://android-review.googlesource.com/" />
-  <default revision="android11-security-release"
+  <default revision="refs/tags/android-security-11.0.0_r1"
            remote="aosp"
            sync-j="4" />
 


### PR DESCRIPTION
Merge tag 'android-security-11.0.0_r53' of https://android.googlesource.com/platform/manifest into arrow-11.0

Android security 11.0.0 release 53

Switched repositories affected by Android security-11.0.0 Release 53 to st-schilling's repositories
Manifest for Android security-11.0.0 Release 53

Change-Id: d6123321038984cc5bdb4aba66fbc6ba1d07c820