### PR TITLE
prepared for manifest for 11.0.0_r53

### DIFF
--- a/arrow.xml
+++ b/arrow.xml
@@ -41,36 +41,36 @@
 
   <!-- packages repos -->
   <project path="packages/apps/ArrowPrebuilts" name="android_packages_apps_ArrowPrebuilts" remote="arrow" clone-depth="1" />
-  <project path="packages/apps/Bluetooth" name="android_packages_apps_Bluetooth" remote="arrow-st-schilling" />
-  <project path="packages/apps/Contacts" name="android_packages_apps_Contacts" remote="arrow-st-schilling" />
+  <project path="packages/apps/Bluetooth" name="android_packages_apps_Bluetooth" remote="arrow" />
+  <project path="packages/apps/Contacts" name="android_packages_apps_Contacts" remote="arrow" />
   <project path="packages/apps/Camera2" name="android_packages_apps_Camera2" remote="arrow" />
   <project path="packages/apps/DeskClock" name="android_packages_apps_DeskClock" remote="arrow" />
   <project path="packages/apps/Dialer" name="android_packages_apps_Dialer" remote="arrow-st-schilling" />
   <project path="packages/apps/FMRadio" name="android_packages_apps_FMRadio" remote="arrow" />
   <project path="packages/apps/Launcher3" name="android_packages_apps_Launcher3" remote="arrow-st-schilling" />
   <project path="packages/apps/Messaging" name="android_packages_apps_Messaging" remote="arrow" />
-  <project path="packages/apps/Nfc" name="android_packages_apps_Nfc" remote="arrow-st-schilling" />
+  <project path="packages/apps/Nfc" name="android_packages_apps_Nfc" remote="arrow" />
   <project path="packages/apps/Settings" name="android_packages_apps_Settings" remote="arrow-st-schilling" />
   <project path="packages/apps/SettingsIntelligence" name="android_packages_apps_SettingsIntelligence" remote="arrow" />
   <project path="packages/apps/Snap" name="android_packages_apps_Snap" remote="arrow" />
   <project path="packages/apps/ThemePicker" name="android_packages_apps_ThemePicker" remote="arrow" />
   <project path="packages/apps/WallpaperPicker2" name="android_packages_apps_WallpaperPicker2" remote="arrow" />
   <project path="packages/inputmethods/LatinIME" name="android_packages_inputmethods_LatinIME" remote="arrow" />
-  <project path="packages/providers/ContactsProvider" name="android_packages_providers_ContactsProvider" remote="arrow-st-schilling" />
+  <project path="packages/providers/ContactsProvider" name="android_packages_providers_ContactsProvider" remote="arrow" />
   <project path="packages/providers/DownloadProvider" name="android_packages_providers_DownloadProvider" remote="arrow-st-schilling" />
   <project path="packages/resources/devicesettings" name="android_packages_resources_devicesettings" remote="arrow" />
-  <project path="packages/services/Telephony" name="android_packages_services_Telephony" remote="arrow-st-schilling" />
-  <project path="packages/services/Telecomm" name="android_packages_services_Telecomm" remote="arrow-st-schilling" />
+  <project path="packages/services/Telephony" name="android_packages_services_Telephony" remote="arrow" />
+  <project path="packages/services/Telecomm" name="android_packages_services_Telecomm" remote="arrow" />
   <project path="packages/services/OmniJaws" name="android_packages_services_OmniJaws" remote="arrow" />
   <project path="packages/apps/Updater" name="android_packages_apps_Updater" remote="arrow" />
-  <project path="packages/modules/NetworkStack" name="android_packages_modules_NetworkStack" remote="arrow-st-schilling" />
+  <project path="packages/modules/NetworkStack" name="android_packages_modules_NetworkStack" remote="arrow" />
   <project path="packages/apps/PermissionController" name="android_packages_apps_PackageInstaller" remote="arrow" />
   <project path="packages/apps/SimpleDeviceConfig" name="android_packages_apps_SimpleDeviceConfig" remote="arrow" />
   <project path="packages/apps/FaceUnlockService" name="android_packages_apps_FaceUnlockService" remote="arrow-gitlab" />
   <project path="packages/apps/CarrierConfig" name="android_packages_apps_CarrierConfig" remote="arrow" />
   <project path="packages/apps/ManagedProvisioning" name="android_packages_apps_ManagedProvisioning" remote="arrow-st-schilling" />
-  <project path="packages/providers/MediaProvider" name="android_packages_providers_MediaProvider" remote="arrow-st-schilling" />
-  <project path="packages/apps/KeyChain" name="android_packages_apps_KeyChain" remote="arrow-st-schilling" />
+  <project path="packages/providers/MediaProvider" name="android_packages_providers_MediaProvider" remote="arrow" />
+  <project path="packages/apps/KeyChain" name="android_packages_apps_KeyChain" remote="arrow" />
 
   <!-- hardware repos -->
   <project path="hardware/qcom-caf/bootctrl" name="android_hardware_qcom_bootctrl" groups="qcom,pdk-qcom" remote="arrow" revision="arrow-11.0-caf" />
@@ -159,11 +159,11 @@
   <project path="hardware/qcom/power" name="android_hardware_qcom_power" groups="qcom,pdk" remote="arrow" />
   <project path="hardware/ril" name="android_hardware_ril" groups="pdk" remote="arrow" />
   <project path="hardware/qcom/bt" name="android_hardware_qcom_bt" groups="qcom" remote="arrow" />
-  <project path="hardware/interfaces" name="android_hardware_interfaces" remote="arrow-st-schilling" />
+  <project path="hardware/interfaces" name="android_hardware_interfaces" remote="arrow" />
   <project path="hardware/arrow/interfaces" name="android_hardware_arrow_interfaces" remote="arrow" />
   <project path="hardware/libhardware" name="android_hardware_libhardware" remote="arrow" />
   <project path="hardware/libhardware_legacy" name="android_hardware_libhardware_legacy" remote="arrow" />
-  <project path="hardware/nxp/nfc" name="android_hardware_nxp_nfc" remote="arrow-st-schilling" />
+  <project path="hardware/nxp/nfc" name="android_hardware_nxp_nfc" remote="arrow" />
 
   <!-- external repos -->
   <project path="external/ant-wireless/ant_client" name="android_external_ant-wireless_ant_client" remote="arrow" />
@@ -173,10 +173,10 @@
   <project path="external/ant-wireless/hidl" name="android_external_ant-wireless_hidl" remote="arrow" />
   <project path="external/chromium-webview" name="android_external_chromium-webview" remote="arrow" revision="master" clone-depth="1" />
   <project path="external/connectivity" name="android_external_connectivity" remote="arrow" />
-  <project path="external/gptfdisk" name="android_external_gptfdisk" remote="arrow-st-schilling" />
+  <project path="external/gptfdisk" name="android_external_gptfdisk" remote="arrow" />
   <project path="external/guice" name="android_external_guice" remote="arrow" />
-  <project path="external/libavc" name="android_external_libavc" remote="arrow-st-schilling" />
-  <project path="external/libexif" name="android_external_libexif" remote="arrow-st-schilling" />
+  <project path="external/libavc" name="android_external_libavc" remote="arrow" />
+  <project path="external/libexif" name="android_external_libexif" remote="arrow" />
   <project path="external/selinux" name="android_external_selinux" remote="arrow" />
   <project path="external/tinycompress" name="android_external_tinycompress" remote="arrow" />
   <project path="external/json-c" name="android_external_json-c" remote="arrow" />
@@ -188,9 +188,9 @@
   <project path="external/e2fsprogs" name="android_external_e2fsprogs" remote="arrow" />
   <project path="external/libnfc-nxp" name="android_external_libnfc-nxp" remote="arrow" />
   <project path="external/faceunlock" name="android_external_faceunlock" remote="arrow-gitlab" />
-  <project path="external/wpa_supplicant_8" name="android_external_wpa_supplicant_8" remote="arrow-st-schilling" />
-  <project path="external/robolectric-shadows" name="android_external_robolectric-shadows" remote="arrow-st-schilling" />
-  <project path="external/tremolo" name="android_external_tremolo" remote="arrow-st-schilling" />
+  <project path="external/wpa_supplicant_8" name="android_external_wpa_supplicant_8" remote="arrow" />
+  <project path="external/robolectric-shadows" name="android_external_robolectric-shadows" remote="arrow" />
+  <project path="external/tremolo" name="android_external_tremolo" remote="arrow" />
 
   <!-- prebuilt repos -->
   <project path="prebuilts/tools-extras" name="android_prebuilts_tools-extras" remote="arrow" />
@@ -200,21 +200,21 @@
 
   <!-- system repos -->
   <project path="system/qcom" name="android_system_qcom" remote="arrow" />
-  <project path="system/core" name="android_system_core" remote="arrow" />
+  <project path="system/core" name="android_system_core" remote="arrow-st-schilling" />
   <project path="system/libufdt" name="android_system_libufdt" remote="arrow" />
-  <project path="system/bt" name="android_system_bt" remote="arrow-st-schilling" />
+  <project path="system/bt" name="android_system_bt" remote="arrow" />
   <project path="system/tools/dtbtool" name="android_system_tools_dtbtool" remote="arrow" />
-  <project path="system/tools/hidl" name="android_system_tools_hidl" remote="arrow-st-schilling" />
+  <project path="system/tools/hidl" name="android_system_tools_hidl" remote="arrow" />
   <project path="system/tools/mkbootimg" name="android_system_tools_mkbootimg" remote="arrow" />
   <project path="system/extras" name="android_system_extras" remote="arrow" />
   <project path="system/incremental_delivery" name="android_system_incremental_delivery" remote="arrow" />
-  <project path="system/netd" name="android_system_netd" remote="arrow-st-schilling" />
+  <project path="system/netd" name="android_system_netd" remote="arrow" />
   <project path="system/vold" name="android_system_vold" groups="pdk" remote="arrow" />
   <project path="system/update_engine" name="android_system_update_engine" groups="pdk" remote="arrow" />
   <project path="system/sepolicy" name="android_system_sepolicy" remote="arrow-st-schilling" />
   <project path="system/media" name="android_system_media" remote="arrow" />
-  <project path="system/nfc" name="android_system_nfc" remote="arrow-st-schilling" />
-  <project path="system/tools/aidl" name="android_system_tools_aidl" remote="arrow-st-schilling" />
+  <project path="system/nfc" name="android_system_nfc" remote="arrow" />
+  <project path="system/tools/aidl" name="android_system_tools_aidl" remote="arrow" />
 
   <!-- tools repos -->
   <project path="tools/extract-utils" name="android_tools_extract-utils" remote="arrow" />


### PR DESCRIPTION
Merge tag 'android-security-11.0.0_r53' of https://android.googlesource.com/platform/manifest into arrow-11.0

Android security 11.0.0 release 53

Switched repositories affected by Android security-11.0.0 Release 53 to st-schilling's repositories
Manifest for Android security-11.0.0 Release 53

Change-Id: d6123321038984cc5bdb4aba66fbc6ba1d07c820