### PR TITLE
Android security 11.0.0 release 54

### DIFF
--- a/arrow.xml
+++ b/arrow.xml
@@ -62,7 +62,7 @@
   <project path="packages/services/Telephony" name="android_packages_services_Telephony" remote="arrow" />
   <project path="packages/services/Telecomm" name="android_packages_services_Telecomm" remote="arrow" />
   <project path="packages/services/OmniJaws" name="android_packages_services_OmniJaws" remote="arrow" />
-  <project path="packages/apps/Updater" name="android_packages_apps_Updater" remote="arrow" />
+  <project path="packages/apps/Updater" name="android_packages_apps_Updater" remote="arrow-st-schilling" />
   <project path="packages/modules/NetworkStack" name="android_packages_modules_NetworkStack" remote="arrow" />
   <project path="packages/apps/PermissionController" name="android_packages_apps_PackageInstaller" remote="arrow" />
   <project path="packages/apps/SimpleDeviceConfig" name="android_packages_apps_SimpleDeviceConfig" remote="arrow" />

--- a/arrow.xml
+++ b/arrow.xml
@@ -69,7 +69,7 @@
   <project path="packages/apps/FaceUnlockService" name="android_packages_apps_FaceUnlockService" remote="arrow-gitlab" />
   <project path="packages/apps/CarrierConfig" name="android_packages_apps_CarrierConfig" remote="arrow" />
   <project path="packages/apps/ManagedProvisioning" name="android_packages_apps_ManagedProvisioning" remote="arrow-st-schilling" />
-  <project path="packages/providers/MediaProvider" name="android_packages_providers_MediaProvider" remote="arrow" />
+  <project path="packages/providers/MediaProvider" name="android_packages_providers_MediaProvider" remote="arrow-st-schilling" />
   <project path="packages/apps/KeyChain" name="android_packages_apps_KeyChain" remote="arrow" />
 
   <!-- hardware repos -->
@@ -202,7 +202,7 @@
   <project path="system/qcom" name="android_system_qcom" remote="arrow" />
   <project path="system/core" name="android_system_core" remote="arrow-st-schilling" />
   <project path="system/libufdt" name="android_system_libufdt" remote="arrow" />
-  <project path="system/bt" name="android_system_bt" remote="arrow" />
+  <project path="system/bt" name="android_system_bt" remote="arrow-st-schilling" />
   <project path="system/tools/dtbtool" name="android_system_tools_dtbtool" remote="arrow" />
   <project path="system/tools/hidl" name="android_system_tools_hidl" remote="arrow" />
   <project path="system/tools/mkbootimg" name="android_system_tools_mkbootimg" remote="arrow" />

--- a/default.xml
+++ b/default.xml
@@ -14,7 +14,7 @@
   <remote  name="arrow-st-schilling"
            fetch="https://github.com/st-schilling"
            review="https://review.arrowos.net/"
-           revision="refs/tags/11.0.0_r53" />
+           revision="refs/tags/11.0.0_r54" />
 
   <remote  name="arrow"
            fetch="https://github.com/ArrowOS"


### PR DESCRIPTION
Android security 11.0.0 release 54

Switched all references of st-schilling provided repositories to 11.0.0 release 54.

New repositories:
- packages/apps/Updater
- packages/providers/MediaProvider
- system/bt