### PR TITLE
Android security 11.0.0 release 56

### DIFF
--- a/arrow.xml
+++ b/arrow.xml
@@ -41,15 +41,15 @@
 
   <!-- packages repos -->
   <project path="packages/apps/ArrowPrebuilts" name="android_packages_apps_ArrowPrebuilts" remote="arrow" clone-depth="1" />
-  <project path="packages/apps/Bluetooth" name="android_packages_apps_Bluetooth" remote="arrow" />
-  <project path="packages/apps/Contacts" name="android_packages_apps_Contacts" remote="arrow" />
+  <project path="packages/apps/Bluetooth" name="android_packages_apps_Bluetooth" remote="arrow-st-schilling" />
+  <project path="packages/apps/Contacts" name="android_packages_apps_Contacts" remote="arrow-st-schilling" />
   <project path="packages/apps/Camera2" name="android_packages_apps_Camera2" remote="arrow" />
   <project path="packages/apps/DeskClock" name="android_packages_apps_DeskClock" remote="arrow" />
   <project path="packages/apps/Dialer" name="android_packages_apps_Dialer" remote="arrow-st-schilling" />
   <project path="packages/apps/FMRadio" name="android_packages_apps_FMRadio" remote="arrow" />
   <project path="packages/apps/Launcher3" name="android_packages_apps_Launcher3" remote="arrow-st-schilling" />
   <project path="packages/apps/Messaging" name="android_packages_apps_Messaging" remote="arrow" />
-  <project path="packages/apps/Nfc" name="android_packages_apps_Nfc" remote="arrow" />
+  <project path="packages/apps/Nfc" name="android_packages_apps_Nfc" remote="arrow-st-schilling" />
   <project path="packages/apps/Settings" name="android_packages_apps_Settings" remote="arrow-st-schilling" />
   <project path="packages/apps/SettingsIntelligence" name="android_packages_apps_SettingsIntelligence" remote="arrow" />
   <project path="packages/apps/Snap" name="android_packages_apps_Snap" remote="arrow" />
@@ -213,7 +213,7 @@
   <project path="system/update_engine" name="android_system_update_engine" groups="pdk" remote="arrow" />
   <project path="system/sepolicy" name="android_system_sepolicy" remote="arrow-st-schilling" />
   <project path="system/media" name="android_system_media" remote="arrow" />
-  <project path="system/nfc" name="android_system_nfc" remote="arrow" />
+  <project path="system/nfc" name="android_system_nfc" remote="arrow-st-schilling" />
   <project path="system/tools/aidl" name="android_system_tools_aidl" remote="arrow" />
 
   <!-- tools repos -->

--- a/default.xml
+++ b/default.xml
@@ -41,10 +41,10 @@
            review="https://android-review.googlesource.com/"
            revision="refs/tags/android-11.0.0_r48" />
 
-  <remote  name="aosp-r56"
+  <remote  name="aosp-security-r56"
            fetch="https://android.googlesource.com/"
            review="https://android-review.googlesource.com/"
-           revision="refs/tags/android-11.0.0_r56" />
+           revision="refs/tags/android-security-11.0.0_r56" />
 
   <default revision="refs/tags/android-11.0.0_r48"
            remote="aosp"
@@ -139,7 +139,7 @@
   <project path="device/sample" name="device/sample" groups="pdk" />
   <project path="device/ti/beagle_x15" name="device/ti/beagle-x15" groups="device,beagle_x15,pdk" />
   <project path="device/ti/beagle_x15-kernel" name="device/ti/beagle-x15-kernel" groups="device,beagle_x15,pdk" clone-depth="1" />
-  <project path="external/aac" name="platform/external/aac" groups="pdk" remote="aosp-r56" />
+  <project path="external/aac" name="platform/external/aac" groups="pdk" remote="aosp-security-r56" />
   <project path="external/adeb" name="platform/external/adeb" groups="pdk" />
   <project path="external/adhd" name="platform/external/adhd" groups="pdk" />
   <project path="external/adt-infra" name="platform/external/adt-infra" groups="adt-infra,notdefault,pdk-fs" />
@@ -639,7 +639,7 @@
   <project path="packages/apps/DevCamera" name="platform/packages/apps/DevCamera" groups="pdk" />
   <project path="packages/apps/Dialer" name="platform/packages/apps/Dialer" groups="pdk-fs" />
   <project path="packages/apps/DocumentsUI" name="platform/packages/apps/DocumentsUI" groups="pdk-cw-fs,pdk-fs" />
-  <project path="packages/apps/EmergencyInfo" name="platform/packages/apps/EmergencyInfo" groups="pdk-fs" remote="aosp-r56" />
+  <project path="packages/apps/EmergencyInfo" name="platform/packages/apps/EmergencyInfo" groups="pdk-fs" remote="aosp-security-r56" />
   <project path="packages/apps/Gallery" name="platform/packages/apps/Gallery" groups="pdk-fs" />
   <project path="packages/apps/Gallery2" name="platform/packages/apps/Gallery2" groups="pdk-fs" />
   <project path="packages/apps/HTMLViewer" name="platform/packages/apps/HTMLViewer" groups="pdk-fs" />

--- a/default.xml
+++ b/default.xml
@@ -14,7 +14,7 @@
   <remote  name="arrow-st-schilling"
            fetch="https://github.com/st-schilling"
            review="https://review.arrowos.net/"
-           revision="refs/tags/11.0.0_r55" />
+           revision="refs/tags/11.0.0_r56" />
 
   <remote  name="arrow"
            fetch="https://github.com/ArrowOS"

--- a/default.xml
+++ b/default.xml
@@ -41,6 +41,11 @@
            review="https://android-review.googlesource.com/"
            revision="refs/tags/android-11.0.0_r48" />
 
+  <remote  name="aosp-r56"
+           fetch="https://android.googlesource.com/"
+           review="https://android-review.googlesource.com/"
+           revision="refs/tags/android-11.0.0_r56" />
+
   <default revision="refs/tags/android-11.0.0_r48"
            remote="aosp"
            sync-j="4"
@@ -134,7 +139,7 @@
   <project path="device/sample" name="device/sample" groups="pdk" />
   <project path="device/ti/beagle_x15" name="device/ti/beagle-x15" groups="device,beagle_x15,pdk" />
   <project path="device/ti/beagle_x15-kernel" name="device/ti/beagle-x15-kernel" groups="device,beagle_x15,pdk" clone-depth="1" />
-  <project path="external/aac" name="platform/external/aac" groups="pdk" />
+  <project path="external/aac" name="platform/external/aac" groups="pdk" remote="aosp-r56" />
   <project path="external/adeb" name="platform/external/adeb" groups="pdk" />
   <project path="external/adhd" name="platform/external/adhd" groups="pdk" />
   <project path="external/adt-infra" name="platform/external/adt-infra" groups="adt-infra,notdefault,pdk-fs" />
@@ -634,7 +639,7 @@
   <project path="packages/apps/DevCamera" name="platform/packages/apps/DevCamera" groups="pdk" />
   <project path="packages/apps/Dialer" name="platform/packages/apps/Dialer" groups="pdk-fs" />
   <project path="packages/apps/DocumentsUI" name="platform/packages/apps/DocumentsUI" groups="pdk-cw-fs,pdk-fs" />
-  <project path="packages/apps/EmergencyInfo" name="platform/packages/apps/EmergencyInfo" groups="pdk-fs" />
+  <project path="packages/apps/EmergencyInfo" name="platform/packages/apps/EmergencyInfo" groups="pdk-fs" remote="aosp-r56" />
   <project path="packages/apps/Gallery" name="platform/packages/apps/Gallery" groups="pdk-fs" />
   <project path="packages/apps/Gallery2" name="platform/packages/apps/Gallery2" groups="pdk-fs" />
   <project path="packages/apps/HTMLViewer" name="platform/packages/apps/HTMLViewer" groups="pdk-fs" />


### PR DESCRIPTION
added repo packages/apps/Bluetooth
added repo packages/apps/Contacts
added repo packages/apps/Nfc
added repo system/nfc
switched platform/external/aac to aosp-security-r56
switched platform/packages/apps/EmergencyInfo to aosp-security-r56
switched to new tag 11.0.0_r56