### PR TITLE
Android security 11.0.0 release 57

### DIFF
--- a/arrow.xml
+++ b/arrow.xml
@@ -35,7 +35,7 @@
   <project path="frameworks/base" name="android_frameworks_base" remote="arrow-st-schilling" />
   <project path="frameworks/libs/systemui" name="android_frameworks_libs_systemui" remote="arrow" />
   <project path="frameworks/native" name="android_frameworks_native" remote="arrow-st-schilling" />
-  <project path="frameworks/opt/telephony" name="android_frameworks_opt_telephony" remote="arrow" />
+  <project path="frameworks/opt/telephony" name="android_frameworks_opt_telephony" remote="arrow-st-schilling" />
   <project path="frameworks/opt/net/ims" name="android_frameworks_opt_net_ims" remote="arrow" />
   <project path="frameworks/opt/net/wifi" name="android_frameworks_opt_net_wifi" remote="arrow" />
 
@@ -70,7 +70,7 @@
   <project path="packages/apps/CarrierConfig" name="android_packages_apps_CarrierConfig" remote="arrow" />
   <project path="packages/apps/ManagedProvisioning" name="android_packages_apps_ManagedProvisioning" remote="arrow-st-schilling" />
   <project path="packages/providers/MediaProvider" name="android_packages_providers_MediaProvider" remote="arrow-st-schilling" />
-  <project path="packages/apps/KeyChain" name="android_packages_apps_KeyChain" remote="arrow" />
+  <project path="packages/apps/KeyChain" name="android_packages_apps_KeyChain" remote="arrow-st-schilling" />
 
   <!-- hardware repos -->
   <project path="hardware/qcom-caf/bootctrl" name="android_hardware_qcom_bootctrl" groups="qcom,pdk-qcom" remote="arrow" revision="arrow-11.0-caf" />

--- a/default.xml
+++ b/default.xml
@@ -14,7 +14,7 @@
   <remote  name="arrow-st-schilling"
            fetch="https://github.com/st-schilling"
            review="https://review.arrowos.net/"
-           revision="refs/tags/11.0.0_r56" />
+           revision="refs/tags/11.0.0_r57" />
 
   <remote  name="arrow"
            fetch="https://github.com/ArrowOS"


### PR DESCRIPTION
Android security 11.0.0 release 57

- Updated reference to Android security 11.0.0 release 57
- added needed new repositories