### PR TITLE
Android security 11.0.0 release 60

### DIFF
--- a/arrow.xml
+++ b/arrow.xml
@@ -56,7 +56,7 @@
   <project path="packages/apps/ThemePicker" name="android_packages_apps_ThemePicker" remote="arrow" />
   <project path="packages/apps/WallpaperPicker2" name="android_packages_apps_WallpaperPicker2" remote="arrow" />
   <project path="packages/inputmethods/LatinIME" name="android_packages_inputmethods_LatinIME" remote="arrow" />
-  <project path="packages/providers/ContactsProvider" name="android_packages_providers_ContactsProvider" remote="arrow" />
+  <project path="packages/providers/ContactsProvider" name="android_packages_providers_ContactsProvider" remote="arrow-st-schilling" />
   <project path="packages/providers/DownloadProvider" name="android_packages_providers_DownloadProvider" remote="arrow-st-schilling" />
   <project path="packages/resources/devicesettings" name="android_packages_resources_devicesettings" remote="arrow" />
   <project path="packages/services/Telephony" name="android_packages_services_Telephony" remote="arrow" />

--- a/default.xml
+++ b/default.xml
@@ -46,6 +46,11 @@
            review="https://android-review.googlesource.com/"
            revision="refs/tags/android-security-11.0.0_r56" />
 
+  <remote  name="aosp-security-r60"
+           fetch="https://android.googlesource.com/"
+           review="https://android-review.googlesource.com/"
+           revision="refs/tags/android-security-11.0.0_r60" />
+
   <default revision="refs/tags/android-11.0.0_r48"
            remote="aosp"
            sync-j="4"
@@ -201,7 +206,7 @@
   <project path="external/dokka" name="platform/external/dokka" groups="pdk" />
   <project path="external/drm_hwcomposer" name="platform/external/drm_hwcomposer" groups="drm_hwcomposer,pdk-fs" />
   <project path="external/drrickorang" name="platform/external/drrickorang" groups="pdk" />
-  <project path="external/dtc" name="platform/external/dtc" groups="pdk"/>
+  <project path="external/dtc" name="platform/external/dtc" groups="pdk" remote="aosp-security-r60"/>
   <project path="external/dynamic_depth" name="platform/external/dynamic_depth" groups="pdk" />
   <project path="external/e2fsprogs" name="platform/external/e2fsprogs" groups="pdk" />
   <project path="external/easymock" name="platform/external/easymock" groups="pdk" />

--- a/default.xml
+++ b/default.xml
@@ -14,7 +14,7 @@
   <remote  name="arrow-st-schilling"
            fetch="https://github.com/st-schilling"
            review="https://review.arrowos.net/"
-           revision="refs/tags/11.0.0_r59" />
+           revision="refs/tags/11.0.0_r60" />
 
   <remote  name="arrow"
            fetch="https://github.com/ArrowOS"


### PR DESCRIPTION
Android security 11.0.0 release 60

- Updated reference to Android security 11.0.0 release 60
- added android_packages_providers_ContactsProvider as new repository
- platform/external/dtc is updated to latest release 60