### PR TITLE
Android security 11.0.0 release 60 - Reverting to ArrowOs repos

### DIFF
--- a/arrow.xml
+++ b/arrow.xml
@@ -195,6 +195,7 @@
   <project path="external/robolectric-shadows" name="android_external_robolectric-shadows" remote="arrow" />
   <project path="external/tremolo" name="android_external_tremolo" remote="arrow" />
   <project path="external/aac" name="android_external_aac" remote="arrow" />
+  <project path="external/expat" name="android_external_expat" remote="arrow" />
 
   <!-- prebuilt repos -->
   <project path="prebuilts/tools-extras" name="android_prebuilts_tools-extras" remote="arrow" />

--- a/arrow.xml
+++ b/arrow.xml
@@ -71,6 +71,9 @@
   <project path="packages/apps/ManagedProvisioning" name="android_packages_apps_ManagedProvisioning" remote="arrow" />
   <project path="packages/providers/MediaProvider" name="android_packages_providers_MediaProvider" remote="arrow" />
   <project path="packages/apps/KeyChain" name="android_packages_apps_KeyChain" remote="arrow" />
+  <project path="packages/apps/Car/Settings" name="android_packages_apps_Car_Settings" remote="arrow" />
+  <project path="packages/apps/EmergencyInfo" name="android_packages_apps_EmergencyInfo" remote="arrow" />
+  <project path="packages/services/Car" name="android_packages_services_Car" remote="arrow" />
 
   <!-- hardware repos -->
   <project path="hardware/qcom-caf/bootctrl" name="android_hardware_qcom_bootctrl" groups="qcom,pdk-qcom" remote="arrow" revision="arrow-11.0-caf" />
@@ -191,6 +194,7 @@
   <project path="external/wpa_supplicant_8" name="android_external_wpa_supplicant_8" remote="arrow" />
   <project path="external/robolectric-shadows" name="android_external_robolectric-shadows" remote="arrow" />
   <project path="external/tremolo" name="android_external_tremolo" remote="arrow" />
+  <project path="external/aac" name="android_external_aac" remote="arrow" />
 
   <!-- prebuilt repos -->
   <project path="prebuilts/tools-extras" name="android_prebuilts_tools-extras" remote="arrow" />

--- a/arrow.xml
+++ b/arrow.xml
@@ -31,8 +31,8 @@
   <project path="device/qcom/sepolicy_vndr" name="android_device_qcom_sepolicy_vndr" remote="arrow" />
 
   <!-- framework repos -->
-  <project path="frameworks/av" name="android_frameworks_av" remote="arrow" />
-  <project path="frameworks/base" name="android_frameworks_base" remote="arrow" />
+  <project path="frameworks/av" name="android_frameworks_av" remote="arrow-st-schilling" />
+  <project path="frameworks/base" name="android_frameworks_base" remote="arrow-st-schilling" />
   <project path="frameworks/libs/systemui" name="android_frameworks_libs_systemui" remote="arrow" />
   <project path="frameworks/native" name="android_frameworks_native" remote="arrow" />
   <project path="frameworks/opt/telephony" name="android_frameworks_opt_telephony" remote="arrow" />

--- a/arrow.xml
+++ b/arrow.xml
@@ -31,36 +31,36 @@
   <project path="device/qcom/sepolicy_vndr" name="android_device_qcom_sepolicy_vndr" remote="arrow" />
 
   <!-- framework repos -->
-  <project path="frameworks/av" name="android_frameworks_av" remote="arrow-st-schilling" />
-  <project path="frameworks/base" name="android_frameworks_base" remote="arrow-st-schilling" />
+  <project path="frameworks/av" name="android_frameworks_av" remote="arrow" />
+  <project path="frameworks/base" name="android_frameworks_base" remote="arrow" />
   <project path="frameworks/libs/systemui" name="android_frameworks_libs_systemui" remote="arrow" />
-  <project path="frameworks/native" name="android_frameworks_native" remote="arrow-st-schilling" />
-  <project path="frameworks/opt/telephony" name="android_frameworks_opt_telephony" remote="arrow-st-schilling" />
+  <project path="frameworks/native" name="android_frameworks_native" remote="arrow" />
+  <project path="frameworks/opt/telephony" name="android_frameworks_opt_telephony" remote="arrow" />
   <project path="frameworks/opt/net/ims" name="android_frameworks_opt_net_ims" remote="arrow" />
   <project path="frameworks/opt/net/wifi" name="android_frameworks_opt_net_wifi" remote="arrow" />
 
   <!-- packages repos -->
   <project path="packages/apps/ArrowPrebuilts" name="android_packages_apps_ArrowPrebuilts" remote="arrow" clone-depth="1" />
-  <project path="packages/apps/Bluetooth" name="android_packages_apps_Bluetooth" remote="arrow-st-schilling" />
-  <project path="packages/apps/Contacts" name="android_packages_apps_Contacts" remote="arrow-st-schilling" />
+  <project path="packages/apps/Bluetooth" name="android_packages_apps_Bluetooth" remote="arrow" />
+  <project path="packages/apps/Contacts" name="android_packages_apps_Contacts" remote="arrow" />
   <project path="packages/apps/Camera2" name="android_packages_apps_Camera2" remote="arrow" />
   <project path="packages/apps/DeskClock" name="android_packages_apps_DeskClock" remote="arrow" />
-  <project path="packages/apps/Dialer" name="android_packages_apps_Dialer" remote="arrow-st-schilling" />
+  <project path="packages/apps/Dialer" name="android_packages_apps_Dialer" remote="arrow" />
   <project path="packages/apps/FMRadio" name="android_packages_apps_FMRadio" remote="arrow" />
-  <project path="packages/apps/Launcher3" name="android_packages_apps_Launcher3" remote="arrow-st-schilling" />
+  <project path="packages/apps/Launcher3" name="android_packages_apps_Launcher3" remote="arrow" />
   <project path="packages/apps/Messaging" name="android_packages_apps_Messaging" remote="arrow" />
-  <project path="packages/apps/Nfc" name="android_packages_apps_Nfc" remote="arrow-st-schilling" />
-  <project path="packages/apps/Settings" name="android_packages_apps_Settings" remote="arrow-st-schilling" />
+  <project path="packages/apps/Nfc" name="android_packages_apps_Nfc" remote="arrow" />
+  <project path="packages/apps/Settings" name="android_packages_apps_Settings" remote="arrow" />
   <project path="packages/apps/SettingsIntelligence" name="android_packages_apps_SettingsIntelligence" remote="arrow" />
   <project path="packages/apps/Snap" name="android_packages_apps_Snap" remote="arrow" />
   <project path="packages/apps/ThemePicker" name="android_packages_apps_ThemePicker" remote="arrow" />
   <project path="packages/apps/WallpaperPicker2" name="android_packages_apps_WallpaperPicker2" remote="arrow" />
   <project path="packages/inputmethods/LatinIME" name="android_packages_inputmethods_LatinIME" remote="arrow" />
-  <project path="packages/providers/ContactsProvider" name="android_packages_providers_ContactsProvider" remote="arrow-st-schilling" />
-  <project path="packages/providers/DownloadProvider" name="android_packages_providers_DownloadProvider" remote="arrow-st-schilling" />
+  <project path="packages/providers/ContactsProvider" name="android_packages_providers_ContactsProvider" remote="arrow" />
+  <project path="packages/providers/DownloadProvider" name="android_packages_providers_DownloadProvider" remote="arrow" />
   <project path="packages/resources/devicesettings" name="android_packages_resources_devicesettings" remote="arrow" />
   <project path="packages/services/Telephony" name="android_packages_services_Telephony" remote="arrow" />
-  <project path="packages/services/Telecomm" name="android_packages_services_Telecomm" remote="arrow-st-schilling" />
+  <project path="packages/services/Telecomm" name="android_packages_services_Telecomm" remote="arrow" />
   <project path="packages/services/OmniJaws" name="android_packages_services_OmniJaws" remote="arrow" />
   <project path="packages/apps/Updater" name="android_packages_apps_Updater" remote="arrow-st-schilling" />
   <project path="packages/modules/NetworkStack" name="android_packages_modules_NetworkStack" remote="arrow" />
@@ -68,9 +68,9 @@
   <project path="packages/apps/SimpleDeviceConfig" name="android_packages_apps_SimpleDeviceConfig" remote="arrow" />
   <project path="packages/apps/FaceUnlockService" name="android_packages_apps_FaceUnlockService" remote="arrow-gitlab" />
   <project path="packages/apps/CarrierConfig" name="android_packages_apps_CarrierConfig" remote="arrow" />
-  <project path="packages/apps/ManagedProvisioning" name="android_packages_apps_ManagedProvisioning" remote="arrow-st-schilling" />
-  <project path="packages/providers/MediaProvider" name="android_packages_providers_MediaProvider" remote="arrow-st-schilling" />
-  <project path="packages/apps/KeyChain" name="android_packages_apps_KeyChain" remote="arrow-st-schilling" />
+  <project path="packages/apps/ManagedProvisioning" name="android_packages_apps_ManagedProvisioning" remote="arrow" />
+  <project path="packages/providers/MediaProvider" name="android_packages_providers_MediaProvider" remote="arrow" />
+  <project path="packages/apps/KeyChain" name="android_packages_apps_KeyChain" remote="arrow" />
 
   <!-- hardware repos -->
   <project path="hardware/qcom-caf/bootctrl" name="android_hardware_qcom_bootctrl" groups="qcom,pdk-qcom" remote="arrow" revision="arrow-11.0-caf" />
@@ -200,9 +200,9 @@
 
   <!-- system repos -->
   <project path="system/qcom" name="android_system_qcom" remote="arrow" />
-  <project path="system/core" name="android_system_core" remote="arrow-st-schilling" />
+  <project path="system/core" name="android_system_core" remote="arrow" />
   <project path="system/libufdt" name="android_system_libufdt" remote="arrow" />
-  <project path="system/bt" name="android_system_bt" remote="arrow-st-schilling" />
+  <project path="system/bt" name="android_system_bt" remote="arrow" />
   <project path="system/tools/dtbtool" name="android_system_tools_dtbtool" remote="arrow" />
   <project path="system/tools/hidl" name="android_system_tools_hidl" remote="arrow" />
   <project path="system/tools/mkbootimg" name="android_system_tools_mkbootimg" remote="arrow" />
@@ -211,9 +211,9 @@
   <project path="system/netd" name="android_system_netd" remote="arrow" />
   <project path="system/vold" name="android_system_vold" groups="pdk" remote="arrow" />
   <project path="system/update_engine" name="android_system_update_engine" groups="pdk" remote="arrow" />
-  <project path="system/sepolicy" name="android_system_sepolicy" remote="arrow-st-schilling" />
+  <project path="system/sepolicy" name="android_system_sepolicy" remote="arrow" />
   <project path="system/media" name="android_system_media" remote="arrow" />
-  <project path="system/nfc" name="android_system_nfc" remote="arrow-st-schilling" />
+  <project path="system/nfc" name="android_system_nfc" remote="arrow" />
   <project path="system/tools/aidl" name="android_system_tools_aidl" remote="arrow" />
 
   <!-- tools repos -->

--- a/remove.xml
+++ b/remove.xml
@@ -97,6 +97,7 @@
   <remove-project name="platform/external/wpa_supplicant_8" />
   <remove-project name="platform/external/robolectric-shadows" />
   <remove-project name="platform/external/tremolo" />
+  <remove-project name="platform/external/aac" />
 
   <!-- packages -->
   <remove-project name="platform/packages/apps/Bluetooth" />
@@ -122,6 +123,9 @@
   <remove-project name="platform/packages/apps/ManagedProvisioning" />
   <remove-project name="platform/packages/providers/MediaProvider" />
   <remove-project name="platform/packages/apps/KeyChain" />
+  <remove-project name="platform/packages/apps/Car/Settings" />
+  <remove-project name="platform/packages/apps/EmergencyInfo" />
+  <remove-project name="platform/packages/services/Car" />
 
   <!-- prebuilts -->
   <remove-project name="platform/prebuilts/abi-dumps/vndk" />

--- a/remove.xml
+++ b/remove.xml
@@ -98,6 +98,7 @@
   <remove-project name="platform/external/robolectric-shadows" />
   <remove-project name="platform/external/tremolo" />
   <remove-project name="platform/external/aac" />
+  <remove-project name="platform/external/expat" />
 
   <!-- packages -->
   <remove-project name="platform/packages/apps/Bluetooth" />


### PR DESCRIPTION
Android security 11.0.0 release 60

Reverting to ArrowOs repos, where possible

- Updated reference to Android security 11.0.0 release 60
- added android_frameworks_av as new repository
- added android_frameworks_base as new repository