### PR TITLE
Android security 11.0.0 release 61

### DIFF
--- a/arrow.xml
+++ b/arrow.xml
@@ -60,7 +60,7 @@
   <project path="packages/providers/DownloadProvider" name="android_packages_providers_DownloadProvider" remote="arrow" />
   <project path="packages/resources/devicesettings" name="android_packages_resources_devicesettings" remote="arrow" />
   <project path="packages/services/Telephony" name="android_packages_services_Telephony" remote="arrow" />
-  <project path="packages/services/Telecomm" name="android_packages_services_Telecomm" remote="arrow" />
+  <project path="packages/services/Telecomm" name="android_packages_services_Telecomm" remote="arrow-st-schilling" />
   <project path="packages/services/OmniJaws" name="android_packages_services_OmniJaws" remote="arrow" />
   <project path="packages/apps/Updater" name="android_packages_apps_Updater" remote="arrow-st-schilling" />
   <project path="packages/modules/NetworkStack" name="android_packages_modules_NetworkStack" remote="arrow" />
@@ -166,7 +166,7 @@
   <project path="hardware/arrow/interfaces" name="android_hardware_arrow_interfaces" remote="arrow" />
   <project path="hardware/libhardware" name="android_hardware_libhardware" remote="arrow" />
   <project path="hardware/libhardware_legacy" name="android_hardware_libhardware_legacy" remote="arrow" />
-  <project path="hardware/nxp/nfc" name="android_hardware_nxp_nfc" remote="arrow" />
+  <project path="hardware/nxp/nfc" name="android_hardware_nxp_nfc" remote="arrow-st-schilling" />
 
   <!-- external repos -->
   <project path="external/ant-wireless/ant_client" name="android_external_ant-wireless_ant_client" remote="arrow" />

--- a/default.xml
+++ b/default.xml
@@ -14,7 +14,7 @@
   <remote  name="arrow-st-schilling"
            fetch="https://github.com/st-schilling"
            review="https://review.arrowos.net/"
-           revision="refs/tags/11.0.0_r60" />
+           revision="refs/tags/11.0.0_r61" />
 
   <remote  name="arrow"
            fetch="https://github.com/ArrowOS"

--- a/default.xml
+++ b/default.xml
@@ -46,10 +46,10 @@
            review="https://android-review.googlesource.com/"
            revision="refs/tags/android-security-11.0.0_r56" />
 
-  <remote  name="aosp-security-r60"
+  <remote  name="aosp-security-r61"
            fetch="https://android.googlesource.com/"
            review="https://android-review.googlesource.com/"
-           revision="refs/tags/android-security-11.0.0_r60" />
+           revision="refs/tags/android-security-11.0.0_r61" />
 
   <default revision="refs/tags/android-11.0.0_r48"
            remote="aosp"
@@ -206,7 +206,7 @@
   <project path="external/dokka" name="platform/external/dokka" groups="pdk" />
   <project path="external/drm_hwcomposer" name="platform/external/drm_hwcomposer" groups="drm_hwcomposer,pdk-fs" />
   <project path="external/drrickorang" name="platform/external/drrickorang" groups="pdk" />
-  <project path="external/dtc" name="platform/external/dtc" groups="pdk" remote="aosp-security-r60"/>
+  <project path="external/dtc" name="platform/external/dtc" groups="pdk" remote="aosp-security-r61"/>
   <project path="external/dynamic_depth" name="platform/external/dynamic_depth" groups="pdk" />
   <project path="external/e2fsprogs" name="platform/external/e2fsprogs" groups="pdk" />
   <project path="external/easymock" name="platform/external/easymock" groups="pdk" />
@@ -708,7 +708,7 @@
   <project path="packages/providers/DownloadProvider" name="platform/packages/providers/DownloadProvider" groups="pdk-cw-fs,pdk-fs" />
   <project path="packages/providers/MediaProvider" name="platform/packages/providers/MediaProvider" groups="pdk-cw-fs,pdk-fs" />
   <project path="packages/providers/PartnerBookmarksProvider" name="platform/packages/providers/PartnerBookmarksProvider" groups="pdk-fs" />
-  <project path="packages/providers/TelephonyProvider" name="platform/packages/providers/TelephonyProvider" groups="pdk-cw-fs,pdk-fs" />
+  <project path="packages/providers/TelephonyProvider" name="platform/packages/providers/TelephonyProvider" groups="pdk-cw-fs,pdk-fs" remote="aosp-security-r61" />
   <project path="packages/providers/TvProvider" name="platform/packages/providers/TvProvider" groups="pdk-fs" />
   <project path="packages/providers/UserDictionaryProvider" name="platform/packages/providers/UserDictionaryProvider" groups="pdk-cw-fs,pdk-fs" />
   <project path="packages/screensavers/Basic" name="platform/packages/screensavers/Basic" groups="pdk-fs" />


### PR DESCRIPTION
Android security 11.0.0 release 61

1. Updated reference to Android security 11.0.0 release 61
2. added as new repository
2.1. android_packages_services_Telecomm 
2.2. android_hardware_nxp_nfc
3. updated to latest AOSP release 61
3.1. platform/external/dtc 
3.2. platform/packages/providers/TelephonyProvider

