### PR TITLE
Android security 11.0.0 release 62

### DIFF
--- a/arrow.xml
+++ b/arrow.xml
@@ -34,7 +34,7 @@
   <project path="frameworks/av" name="android_frameworks_av" remote="arrow-st-schilling" />
   <project path="frameworks/base" name="android_frameworks_base" remote="arrow-st-schilling" />
   <project path="frameworks/libs/systemui" name="android_frameworks_libs_systemui" remote="arrow" />
-  <project path="frameworks/native" name="android_frameworks_native" remote="arrow" />
+  <project path="frameworks/native" name="android_frameworks_native" remote="arrow-st-schilling" />
   <project path="frameworks/opt/telephony" name="android_frameworks_opt_telephony" remote="arrow" />
   <project path="frameworks/opt/net/ims" name="android_frameworks_opt_net_ims" remote="arrow" />
   <project path="frameworks/opt/net/wifi" name="android_frameworks_opt_net_wifi" remote="arrow" />
@@ -69,7 +69,7 @@
   <project path="packages/apps/FaceUnlockService" name="android_packages_apps_FaceUnlockService" remote="arrow-gitlab" />
   <project path="packages/apps/CarrierConfig" name="android_packages_apps_CarrierConfig" remote="arrow" />
   <project path="packages/apps/ManagedProvisioning" name="android_packages_apps_ManagedProvisioning" remote="arrow" />
-  <project path="packages/providers/MediaProvider" name="android_packages_providers_MediaProvider" remote="arrow" />
+  <project path="packages/providers/MediaProvider" name="android_packages_providers_MediaProvider" remote="arrow-st-schilling" />
   <project path="packages/apps/KeyChain" name="android_packages_apps_KeyChain" remote="arrow" />
   <project path="packages/apps/Car/Settings" name="android_packages_apps_Car_Settings" remote="arrow" />
   <project path="packages/apps/EmergencyInfo" name="android_packages_apps_EmergencyInfo" remote="arrow" />

--- a/arrow.xml
+++ b/arrow.xml
@@ -41,7 +41,7 @@
 
   <!-- packages repos -->
   <project path="packages/apps/ArrowPrebuilts" name="android_packages_apps_ArrowPrebuilts" remote="arrow" clone-depth="1" />
-  <project path="packages/apps/Bluetooth" name="android_packages_apps_Bluetooth" remote="arrow" />
+  <project path="packages/apps/Bluetooth" name="android_packages_apps_Bluetooth" remote="arrow-st-schilling" />
   <project path="packages/apps/Contacts" name="android_packages_apps_Contacts" remote="arrow" />
   <project path="packages/apps/Camera2" name="android_packages_apps_Camera2" remote="arrow" />
   <project path="packages/apps/DeskClock" name="android_packages_apps_DeskClock" remote="arrow" />
@@ -50,7 +50,7 @@
   <project path="packages/apps/Launcher3" name="android_packages_apps_Launcher3" remote="arrow" />
   <project path="packages/apps/Messaging" name="android_packages_apps_Messaging" remote="arrow" />
   <project path="packages/apps/Nfc" name="android_packages_apps_Nfc" remote="arrow" />
-  <project path="packages/apps/Settings" name="android_packages_apps_Settings" remote="arrow" />
+  <project path="packages/apps/Settings" name="android_packages_apps_Settings" remote="arrow-st-schilling" />
   <project path="packages/apps/SettingsIntelligence" name="android_packages_apps_SettingsIntelligence" remote="arrow" />
   <project path="packages/apps/Snap" name="android_packages_apps_Snap" remote="arrow" />
   <project path="packages/apps/ThemePicker" name="android_packages_apps_ThemePicker" remote="arrow" />

--- a/default.xml
+++ b/default.xml
@@ -14,7 +14,7 @@
   <remote  name="arrow-st-schilling"
            fetch="https://github.com/st-schilling"
            review="https://review.arrowos.net/"
-           revision="refs/tags/11.0.0_r61" />
+           revision="refs/tags/11.0.0_r62" />
 
   <remote  name="arrow"
            fetch="https://github.com/ArrowOS"

--- a/default.xml
+++ b/default.xml
@@ -41,15 +41,10 @@
            review="https://android-review.googlesource.com/"
            revision="refs/tags/android-11.0.0_r48" />
 
-  <remote  name="aosp-security-r56"
+  <remote  name="aosp-security-r62"
            fetch="https://android.googlesource.com/"
            review="https://android-review.googlesource.com/"
-           revision="refs/tags/android-security-11.0.0_r56" />
-
-  <remote  name="aosp-security-r61"
-           fetch="https://android.googlesource.com/"
-           review="https://android-review.googlesource.com/"
-           revision="refs/tags/android-security-11.0.0_r61" />
+           revision="refs/tags/android-security-11.0.0_r62" />
 
   <default revision="refs/tags/android-11.0.0_r48"
            remote="aosp"
@@ -144,7 +139,7 @@
   <project path="device/sample" name="device/sample" groups="pdk" />
   <project path="device/ti/beagle_x15" name="device/ti/beagle-x15" groups="device,beagle_x15,pdk" />
   <project path="device/ti/beagle_x15-kernel" name="device/ti/beagle-x15-kernel" groups="device,beagle_x15,pdk" clone-depth="1" />
-  <project path="external/aac" name="platform/external/aac" groups="pdk" remote="aosp-security-r56" />
+  <project path="external/aac" name="platform/external/aac" groups="pdk" remote="aosp-security-r62" />
   <project path="external/adeb" name="platform/external/adeb" groups="pdk" />
   <project path="external/adhd" name="platform/external/adhd" groups="pdk" />
   <project path="external/adt-infra" name="platform/external/adt-infra" groups="adt-infra,notdefault,pdk-fs" />
@@ -206,7 +201,7 @@
   <project path="external/dokka" name="platform/external/dokka" groups="pdk" />
   <project path="external/drm_hwcomposer" name="platform/external/drm_hwcomposer" groups="drm_hwcomposer,pdk-fs" />
   <project path="external/drrickorang" name="platform/external/drrickorang" groups="pdk" />
-  <project path="external/dtc" name="platform/external/dtc" groups="pdk" remote="aosp-security-r61"/>
+  <project path="external/dtc" name="platform/external/dtc" groups="pdk" remote="aosp-security-r62"/>
   <project path="external/dynamic_depth" name="platform/external/dynamic_depth" groups="pdk" />
   <project path="external/e2fsprogs" name="platform/external/e2fsprogs" groups="pdk" />
   <project path="external/easymock" name="platform/external/easymock" groups="pdk" />
@@ -516,7 +511,7 @@
   <project path="frameworks/libs/modules-utils" name="platform/frameworks/libs/modules-utils" groups="pdk-cw-fs,pdk-fs" />
   <project path="frameworks/libs/native_bridge_support" name="platform/frameworks/libs/native_bridge_support" groups="pdk" />
   <project path="frameworks/libs/net" name="platform/frameworks/libs/net" groups="pdk-cw-fs,pdk-fs" />
-  <project path="frameworks/minikin" name="platform/frameworks/minikin" groups="pdk-cw-fs,pdk-fs" />
+  <project path="frameworks/minikin" name="platform/frameworks/minikin" groups="pdk-cw-fs,pdk-fs"  remote="aosp-security-r62" />
   <project path="frameworks/ml" name="platform/frameworks/ml" groups="pdk" />
   <project path="frameworks/multidex" name="platform/frameworks/multidex" groups="pdk-cw-fs,pdk-fs" />
   <project path="frameworks/native" name="platform/frameworks/native" groups="pdk" />
@@ -581,7 +576,7 @@
   <project path="hardware/qcom/sdm845/media" name="platform/hardware/qcom/sdm845/media" groups="generic_fs,qcom_sdm845" />
   <project path="hardware/qcom/sdm845/thermal" name="platform/hardware/qcom/sdm845/thermal" groups="generic_fs,qcom_sdm845" />
   <project path="hardware/qcom/sdm845/vr" name="platform/hardware/qcom/sdm845/vr" groups="generic_fs,qcom_sdm845" />
-  <project path="hardware/qcom/sm7150/gps" name="platform/hardware/qcom/sm7150/gps" groups="qcom_sm7150"  remote="aosp-r48" >
+  <project path="hardware/qcom/sm7150/gps" name="platform/hardware/qcom/sm7150/gps" groups="qcom_sm7150"  remote="aosp-security-r62" >
     <linkfile src="os_pickup.mk" dest="hardware/qcom/sm7150/Android.mk" />
     <linkfile src="os_pickup.bp" dest="hardware/qcom/sm7150/Android.bp" />
   </project>
@@ -644,7 +639,7 @@
   <project path="packages/apps/DevCamera" name="platform/packages/apps/DevCamera" groups="pdk" />
   <project path="packages/apps/Dialer" name="platform/packages/apps/Dialer" groups="pdk-fs" />
   <project path="packages/apps/DocumentsUI" name="platform/packages/apps/DocumentsUI" groups="pdk-cw-fs,pdk-fs" />
-  <project path="packages/apps/EmergencyInfo" name="platform/packages/apps/EmergencyInfo" groups="pdk-fs" remote="aosp-security-r56" />
+  <project path="packages/apps/EmergencyInfo" name="platform/packages/apps/EmergencyInfo" groups="pdk-fs" remote="aosp-security-r62" />
   <project path="packages/apps/Gallery" name="platform/packages/apps/Gallery" groups="pdk-fs" />
   <project path="packages/apps/Gallery2" name="platform/packages/apps/Gallery2" groups="pdk-fs" />
   <project path="packages/apps/HTMLViewer" name="platform/packages/apps/HTMLViewer" groups="pdk-fs" />
@@ -708,7 +703,7 @@
   <project path="packages/providers/DownloadProvider" name="platform/packages/providers/DownloadProvider" groups="pdk-cw-fs,pdk-fs" />
   <project path="packages/providers/MediaProvider" name="platform/packages/providers/MediaProvider" groups="pdk-cw-fs,pdk-fs" />
   <project path="packages/providers/PartnerBookmarksProvider" name="platform/packages/providers/PartnerBookmarksProvider" groups="pdk-fs" />
-  <project path="packages/providers/TelephonyProvider" name="platform/packages/providers/TelephonyProvider" groups="pdk-cw-fs,pdk-fs" remote="aosp-security-r61" />
+  <project path="packages/providers/TelephonyProvider" name="platform/packages/providers/TelephonyProvider" groups="pdk-cw-fs,pdk-fs" remote="aosp-security-r62" />
   <project path="packages/providers/TvProvider" name="platform/packages/providers/TvProvider" groups="pdk-fs" />
   <project path="packages/providers/UserDictionaryProvider" name="platform/packages/providers/UserDictionaryProvider" groups="pdk-cw-fs,pdk-fs" />
   <project path="packages/screensavers/Basic" name="platform/packages/screensavers/Basic" groups="pdk-fs" />


### PR DESCRIPTION
Android security 11.0.0 release 62

1. Updated reference to Android security 11.0.0 release 62
2. added as new repository
2.1. android_packages_apps_Bluetooth
2.2. android_packages_apps_Settings
2.3. android_frameworks_native
2.4. android_packages_providers_MediaProvider
3. updated to latest AOSP release 62
3.1. all repos from release 61
3.2. platform/external/aac
3.3. platform/external/dtc
3.4. platform/frameworks/minikin
3.5. platform/hardware/qcom/sm7150/gps
3.6. platform/packages/apps/EmergencyInfo
3.7. platform/packages/providers/TelephonyProvider