### PR TITLE
Android security 11.0.0 release 76

### DIFF
--- a/arrow.xml
+++ b/arrow.xml
@@ -57,7 +57,7 @@
   <project path="packages/apps/WallpaperPicker2" name="android_packages_apps_WallpaperPicker2" remote="arrow" />
   <project path="packages/inputmethods/LatinIME" name="android_packages_inputmethods_LatinIME" remote="arrow" />
   <project path="packages/providers/ContactsProvider" name="android_packages_providers_ContactsProvider" remote="arrow" />
-  <project path="packages/providers/DownloadProvider" name="android_packages_providers_DownloadProvider" remote="arrow" />
+  <project path="packages/providers/DownloadProvider" name="android_packages_providers_DownloadProvider" remote="arrow-st-schilling" />
   <project path="packages/resources/devicesettings" name="android_packages_resources_devicesettings" remote="arrow" />
   <project path="packages/services/Telephony" name="android_packages_services_Telephony" remote="arrow-st-schilling" />
   <project path="packages/services/Telecomm" name="android_packages_services_Telecomm" remote="arrow-st-schilling" />

--- a/arrow.xml
+++ b/arrow.xml
@@ -205,7 +205,7 @@
 
   <!-- system repos -->
   <project path="system/qcom" name="android_system_qcom" remote="arrow" />
-  <project path="system/core" name="android_system_core" remote="arrow" />
+  <project path="system/core" name="android_system_core" remote="arrow-st-schilling" />
   <project path="system/libufdt" name="android_system_libufdt" remote="arrow" />
   <project path="system/bt" name="android_system_bt" remote="arrow-st-schilling" />
   <project path="system/tools/dtbtool" name="android_system_tools_dtbtool" remote="arrow" />

--- a/default.xml
+++ b/default.xml
@@ -14,7 +14,7 @@
   <remote  name="arrow-st-schilling"
            fetch="https://github.com/st-schilling"
            review="https://review.arrowos.net/"
-           revision="refs/tags/11.0.0_r75" />
+           revision="refs/tags/11.0.0_r76" />
 
   <remote  name="arrow"
            fetch="https://github.com/ArrowOS"
@@ -385,7 +385,7 @@
   <project path="external/owasp/sanitizer" name="platform/external/owasp/sanitizer" groups="pdk" />
   <project path="external/parameter-framework" name="platform/external/parameter-framework" groups="pdk" />
   <project path="external/pcre" name="platform/external/pcre" groups="pdk" />
-  <project path="external/pdfium" name="platform/external/pdfium" groups="pdk" />
+  <project path="external/pdfium" name="platform/external/pdfium" groups="pdk" remote="aosp-security-r73" />
   <project path="external/perfetto" name="platform/external/perfetto" groups="pdk" />
   <project path="external/piex" name="platform/external/piex" groups="pdk" />
   <project path="external/ply" name="platform/external/ply" groups="pdk" />


### PR DESCRIPTION
Android security 11.0.0 release 76

Updated references to Android security 11.0.0 release 76 of February 2024.